### PR TITLE
Specify `triplesec` as dependency and shift `extra` bytes

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -119,7 +119,7 @@
         });
         encryptor.resalt({
           salt: salt,
-          extra_keymaterial: 64
+          extra_keymaterial: 96
         }, esc(__iced_deferrals.defer({
           assign_fn: (function() {
             return function() {
@@ -132,8 +132,8 @@
           yield;
         }
         return cb(null, {
-          key4: extra.slice(0, 32),
-          key5: extra.slice(32, 64)
+          key4: extra.slice(32, 64),
+          key5: extra.slice(64, 96)
         });
       };
     })(this)();

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "keybase-proofs": "^2.0.58",
     "read": "^1.0.7",
     "request": "^2.78.0",
-    "triplesec": "^3.0.25"
+    "triplesec": "^4.0.3"
   }
 }

--- a/src/login.iced
+++ b/src/login.iced
@@ -35,8 +35,8 @@ get_salt = ({username, email}, cb) ->
 strech_passphrase = ({salt, passphrase}, cb) ->
   esc = make_esc cb, "make_keys"
   encryptor = new triplesec.Encryptor {key : (new Buffer passphrase, "utf8") }
-  await encryptor.resalt { salt, extra_keymaterial : 64 }, esc defer {extra}
-  cb null, { key4 : extra[0...32], key5 : extra[32...64] }
+  await encryptor.resalt { salt, extra_keymaterial : 96 }, esc defer {extra}
+  cb null, { key4 : extra[32...64], key5 : extra[64...96] }
 
 make_sig = ({key, email, username, session}, cb) ->
   esc = make_esc cb, "make_sig"


### PR DESCRIPTION
I stumbled upon this example while trying to setup a login in node and banged my head against it for a _while_ until I ended up comparing dependency versions and the string-ed output of `Encryptor.resalt`. Eventually I realized that the `extra` buffer was shifted to the right 32 bytes in `triplesec@3.0.27` as compared to `triplesec@4.0.1`.

I have no idea why this is, or what implications it might have. The ~only~ main changes between those releases seem to be related to the deprecated `Buffer` creation approach, and that's pretty wide-spread. (re: https://github.com/keybase/triplesec/compare/v3.0.27...v4.0.1)

At any rate, when I took into consideration this additional shift and took my `extra` bytes from the end of that, the example worked as expected.

Regardless of the importance of this change, I'd be curious to know the cause of this is.